### PR TITLE
Fixes loading track info from age-restricted YouTube videos - Fixes #521

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -156,7 +156,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
       HttpClientTools.assertSuccessWithContent(response, "embed video page response");
 
       String html = EntityUtils.toString(response.getEntity(), UTF_8);
-      String configJson = DataFormatTools.extractBetween(html, "'PLAYER_CONFIG': ", "});writeEmbed();");
+      String configJson = DataFormatTools.extractBetween(html, "'PLAYER_CONFIG': ", "});yt.setConfig");
 
       if (configJson != null) {
         return JsonBrowser.parse(configJson);


### PR DESCRIPTION
This fixes issue [sedmelluq#521](https://github.com/sedmelluq/lavaplayer/issues/521) - "FriendlyException: Track information is unavailable when playing age restricted videos."

**What I changed:**

I changed the end of the string, where the split is done, from `});writeEmbed();` to `});yt.setConfig`.
I think YouTube has changed its format, so it needed to be updated. This part can be rewritten to be future proof, but I didn't want to do that.

I tested this change using a JDA bot with this YouTube video (slightly NSFW): https://www.youtube.com/watch?v=EX_8ZjT2sO4